### PR TITLE
fixing LICENSE mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ This github repository hosts the [OpenSCAD](http://www.openscad.org) source and 
 
 ![oshw-logo-200-px.png](images/oshw-logo-200-px.png)
 
-Hardware designs (schematics and CAD) files are licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/) and follow the terms of the [OSHW (Open-source hardware) Statement of Principles 1.0.](http://freedomdefined.org/OSHW)
+Hardware designs (schematics and CAD) files are licensed under the [GNU GENERAL PUBLIC LICENSE Version 3](https://www.gnu.org/licenses/gpl-3.0.md) and follow the terms of the [OSHW (Open-source hardware) Statement of Principles 1.0.](http://freedomdefined.org/OSHW)


### PR DESCRIPTION
README mentiones CC-BY-SA-3.0, but the LICENSE file uses GPLv3's legal code → so I assumed the README entry is faulty :)